### PR TITLE
開発フローの変更（Stagingブランチの削除）

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,12 +72,10 @@
 - `main`:
   - 常に安定。公開用の履歴として管理します。
   - 直接 push は行わず、PR を通して更新します。
-- `staging`:
-  - 機能統合の一時的な確認用。`feature/*` をここに集約して動作確認してから `main` に反映します。
 - `feature/<topic>`:
-  - 機能追加や改善の作業ブランチ。作業が完了したら `staging` へ PR を作成します。
+  - 機能追加や改善の作業ブランチ。作業が完了したら `main` へ PR を作成します。
 - `hotfix/<topic>`:
-  - 緊急修正用。`main` へ直接 PR を作成し、マージ後は `staging` へバックマージ。
+  - 緊急修正用。`main` へ直接 PR を作成します。
 
 ## 🤝 開発フロー
 
@@ -85,16 +83,14 @@
 
 1. `feature/<topic>` ブランチを作成
 2. 実装・コミット
-3. `feature/<topic>` → `staging` に PR 作成
-4. レビュー後、`staging` にマージ
-5. `staging` → `main` に PR 作成してリリース
-6. ローカルブランチのクリーンアップ
+3. `feature/<topic>` → `main` に PR 作成
+4. セルフレビュー後、`main` にマージ
+5. ローカルブランチのクリーンアップ
 
 ### 緊急修正
 
 1. `hotfix/<topic>` ブランチを作成
 2. `main` に直接 PR 作成・マージ
-3. `staging` へバックマージして同期
 
 詳細な手順、コミット規約、PR の書き方は [CONTRIBUTING.md](./docs/CONTRIBUTING.md) を参照してください。
 

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -5,7 +5,6 @@
 ## ブランチ運用
 
 - `main`: 常に安定。PR経由のみで更新。
-- `staging`: 統合確認用。`feature/*` をここに集約。
 - `feature/<topic>`: 機能追加・改善。例: `feature/add-weather-client`
 - `hotfix/<topic>`: 緊急修正。例: `hotfix/fix-build-error`
 
@@ -20,17 +19,16 @@ git push -u origin feature/add-weather-client
 
 ### 通常フロー（feature ブランチ）
 
-1. `feature/<topic>` → `staging` に PR を作成
+1. `feature/<topic>` → `main` に PR を作成
 2. PR テンプレートのチェックリストを埋める（説明・影響範囲・動作確認）
 3. Files changed タブでセルフレビュー
-4. 問題なければ `staging` にマージ
-5. `staging` → `main` に PR を作成し、同様に確認してマージ
-6. マージ完了後、ローカルの `main` ブランチを更新
+4. 問題なければ `main` にマージ
+5. マージ完了後、ローカルの `main` ブランチを更新
    ```bash
    git checkout main
    git pull origin main
    ```
-7. 完了した `feature/<topic>` ブランチを削除
+6. 完了した `feature/<topic>` ブランチを削除
    ```bash
    git branch -d feature/<topic>
    git push origin --delete feature/<topic>
@@ -40,14 +38,8 @@ git push -u origin feature/add-weather-client
 
 1. `main` から `hotfix/<topic>` を作成
 2. 修正を実施
-3. `hotfix/<topic>` → `main` に PR を作成（緊急リリース）
-4. マージ後、`main` → `staging` に変更を反映（バックマージ）
-   ```bash
-   git checkout staging
-   git merge main
-   git push origin staging
-   ```
-5. hotfix ブランチを削除
+3. `hotfix/<topic>` → `main` に PR を作成・マージ
+4. hotfix ブランチを削除
 
 ### PR の書き方（推奨）
 
@@ -84,7 +76,5 @@ git push -u origin feature/add-weather-client
 - `main`:
   - 直接 push 禁止（PR 必須）
   - レビュー必須（1 承認）ただし個人運用のため、必要に応じて管理者例外でマージ可
-- `staging`:
-  - 任意で保護（PR 推奨）
 
 CI（自動テスト・ビルド）は後から導入予定。導入時は `main` の必須チェックに追加します。


### PR DESCRIPTION
## 概要

Stagingブランチの削除

- 間違ってmainにマージしてしまうことが度々あった
- そもそも、個人開発でstagingまであるのは大げさ
- 開発効率を下げる

## 変更点

- 主にドキュメントの修正
- 同時にGitHub上のブランチも削除
